### PR TITLE
Use Test::Requires for checking the modules installed

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -35,6 +35,7 @@ on test => sub {
     requires 'Mouse::Util';
     requires 'Test::Builder::Module';
     requires 'Test::More', '0.98';
+    requires 'Test::Requires';
     requires 'feature';
 };
 

--- a/t/handler/weighted_round_robin.t
+++ b/t/handler/weighted_round_robin.t
@@ -3,16 +3,13 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Test::Requires qw(Data::WeightedRoundRobin);
 
 use File::Spec;
 use lib File::Spec->catfile('t', 'lib');
 
 use Aniki::Handler::WeightedRoundRobin;
 use List::Util qw/reduce/;
-
-if (!eval { require Data::WeightedRoundRobin; 1 }) {
-    plan skip_all => 'Data::WeightedRoundRobin is required for WeightedRoundRobin handler';
-}
 
 srand 4649;
 

--- a/t/plugin/select_joined/select_joined.t
+++ b/t/plugin/select_joined/select_joined.t
@@ -3,15 +3,12 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Test::Requires qw(SQL::Maker::Plugin::JoinSelect);
 
 use File::Spec;
 use lib File::Spec->catfile('t', 'lib');
 use Mouse::Util;
 use t::Util;
-
-if (!eval { require SQL::Maker::Plugin::JoinSelect; 1 }) {
-    plan skip_all => 'SQL::Maker::Plugin::JoinSelect is required for SelectJoined';
-}
 
 my $db = t::Util->db;
 Mouse::Util::apply_all_roles($db, 'Aniki::Plugin::SelectJoined');

--- a/t/plugin/weighted_round_robin/weighted_round_robin.t
+++ b/t/plugin/weighted_round_robin/weighted_round_robin.t
@@ -3,15 +3,12 @@ use warnings;
 use utf8;
 
 use Test::More;
+use Test::Requires qw(Data::WeightedRoundRobin);
 
 use File::Spec;
 use lib File::Spec->catfile('t', 'lib');
 use Mouse::Util;
 use t::Util;
-
-if (!eval { require Data::WeightedRoundRobin; 1 }) {
-    plan skip_all => 'Data::WeightedRoundRobin is required for WeightedRoundRobin plugin';
-}
 
 my $db = t::Util->db;
 Mouse::Util::apply_all_roles($db, 'Aniki::Plugin::WeightedRoundRobin');


### PR DESCRIPTION
`t/handler/weighted_round_robin.t` is failed. Checking whether module is installed should be at compile time, not runtime. I suppose `Test::Requires` achieves it easy.

```
% prove -bv t/handler/weighted_round_robin.t
t/handler/weighted_round_robin.t .. Can't locate Data/WeightedRoundRobin.pm in @INC (you may need to install the Data::WeightedRoundRobin module) (@INC contains: t/lib /home/syohei/.cpanm/work/1445925795.27872/Aniki-0.81/blib/lib /home/syohei/.cpanm/work/1445925795.27872/Aniki-0.81/blib/arch /home/syohei/.plenv/versions/5.22.0/lib/perl5/site_perl/5.22.0/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.22.0/lib/perl5/site_perl/5.22.0 /home/syohei/.plenv/versions/5.22.0/lib/perl5/5.22.0/x86_64-linux-thread-multi /home/syohei/.plenv/versions/5.22.0/lib/perl5/5.22.0 .) at /home/syohei/.cpanm/work/1445925795.27872/Aniki-0.81/blib/lib/Aniki/Handler/WeightedRoundRobin.pm line 10.
BEGIN failed--compilation aborted at /home/syohei/.cpanm/work/1445925795.27872/Aniki-0.81/blib/lib/Aniki/Handler/WeightedRoundRobin.pm line 10.
Compilation failed in require at t/handler/weighted_round_robin.t line 10.
BEGIN failed--compilation aborted at t/handler/weighted_round_robin.t line 10.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 

Test Summary Report
-------------------
t/handler/weighted_round_robin.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  0 wallclock secs ( 0.00 usr  0.00 sys +  0.03 cusr  0.00 csys =  0.03 CPU)
Result: FAIL
```
