### PR TITLE
fix range condition maker

### DIFF
--- a/lib/Aniki/Plugin/RangeConditionMaker.pm
+++ b/lib/Aniki/Plugin/RangeConditionMaker.pm
@@ -5,7 +5,7 @@ use namespace::sweep;
 use Mouse::Role;
 
 use Carp qw/carp croak/;
-use SQL::QueryMaker qw/sql_gt sql_lt/;
+use SQL::QueryMaker qw/sql_gt sql_lt sql_and/;
 
 sub make_range_condtion {
     carp '[INCOMPATIBLE CHANGE Aniki@1.02] This method is renamed to make_range_condition. the old method is removed at 1.03.';
@@ -33,7 +33,7 @@ sub make_range_condition {
 
             my $condition = $func->($range_condition->{$column});
             $total_range_condition{$column} =
-                exists $total_range_condition{$column} ? [-and => $total_range_condition{$column}, $condition]
+                exists $total_range_condition{$column} ? sql_and([$total_range_condition{$column}, $condition])
                                                        : $condition;
         }
     }

--- a/t/plugin/range_condition_maker/make_range_condition.t
+++ b/t/plugin/range_condition_maker/make_range_condition.t
@@ -37,6 +37,11 @@ run_on_database {
         my $result = db->select('author', $where);
         is scalar (map { $_->{id} < 4 } @{ $result->row_datas }), 3;
     }
+
+    my $where  = db->make_range_condition({ lower => { id => 1 }, upper => { id => 3 } });
+    my $result = db->select('author', $where);
+    is scalar @{$result->row_datas}, 1;
+    is $result->row_datas->[0]->{id}, 2;
 };
 
 done_testing();


### PR DESCRIPTION

`use_strict_query_builder`が1になっているためSQL::Makerでエラーになっていました。
strictが有効でも動くよう対応を行いました。

https://github.com/tokuhirom/SQL-Maker/blob/master/lib/SQL/Maker/Condition.pm#L36

error
```
$ prove -lvr t/plugin/range_condition_maker/make_range_condition.t
t/plugin/range_condition_maker/make_range_condition.t ..
# Subtest: SQLite
    # prepare sqlite ...
    ok 1
    ok 2
    ok 3
    ok 4
    ok 5
    1..5
ok 1 - SQLite
cannot pass in an unblessed ref as an argument in strict mode at Aniki/lib/Aniki.pm line 443.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 1.
Dubious, test returned 255 (wstat 65280, 0xff00)
All 1 subtests passed

Test Summary Report
-------------------
t/plugin/range_condition_maker/make_range_condition.t (Wstat: 65280 Tests: 1 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
Files=1, Tests=1,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.26 cusr  0.03 csys =  0.31 CPU)
Result: FAIL
```

